### PR TITLE
Fix Player.Update unsheathe water check (Fixes #5)

### DIFF
--- a/Plugin.cs
+++ b/Plugin.cs
@@ -125,7 +125,7 @@ namespace HS_EquipInWater
             {
                 List<CodeInstruction> instructionList = instructions.ToList();
 
-                for (int i = 218; i <= 223; i++)
+                for (int i = 222; i <= 227; i++)
                 {
                     CodeInstruction instruction = instructionList[i];
                     instruction.opcode = OpCodes.Nop;

--- a/Plugin.cs
+++ b/Plugin.cs
@@ -125,7 +125,7 @@ namespace HS_EquipInWater
             {
                 List<CodeInstruction> instructionList = instructions.ToList();
 
-                for (int i = 202; i <= 207; i++)
+                for (int i = 218; i <= 223; i++)
                 {
                     CodeInstruction instruction = instructionList[i];
                     instruction.opcode = OpCodes.Nop;


### PR DESCRIPTION
Update the indices of the instructions in Player.Update to NOP for the current (0.217.31) version of the game. This fixes #5.